### PR TITLE
Changes to allow the ability to remove loadbalancers in ERROR status

### DIFF
--- a/core-api/core-common-api/src/main/java/org/openstack/atlas/api/async/CreateLoadBalancerListener.java
+++ b/core-api/core-common-api/src/main/java/org/openstack/atlas/api/async/CreateLoadBalancerListener.java
@@ -75,6 +75,7 @@ public class CreateLoadBalancerListener extends BaseListener {
             LOG.debug("Successfully created a load balancer via adapter.");
         } catch (Exception e) {
             dbLoadBalancer.setStatus(ERROR);
+            dbLoadBalancer.setCreatedOnAdapter(false);
             NodesHelper.setNodesToStatus(dbLoadBalancer, CoreNodeStatus.OFFLINE);
             loadBalancerRepository.update(dbLoadBalancer);
             String alertDescription = String.format("An error occurred while creating loadbalancer '%d' via adapter.", dbLoadBalancer.getId());
@@ -86,6 +87,7 @@ public class CreateLoadBalancerListener extends BaseListener {
 
         // Update load balancer in DB
         dbLoadBalancer.setStatus(ACTIVE);
+        dbLoadBalancer.setCreatedOnAdapter(true);
         NodesHelper.setNodesToStatus(dbLoadBalancer, CoreNodeStatus.ONLINE);
         dbLoadBalancer = loadBalancerRepository.update(dbLoadBalancer);
 

--- a/core-persistence/src/main/java/org/openstack/atlas/service/domain/entity/LoadBalancer.java
+++ b/core-persistence/src/main/java/org/openstack/atlas/service/domain/entity/LoadBalancer.java
@@ -46,6 +46,9 @@ public class LoadBalancer extends Entity implements Serializable {
     @Column(name = "status", nullable = false)
     private String status;
 
+    @Column(name = "created_on_adapter", nullable = true)
+    private Boolean created_on_adapter;
+
     @OneToMany(mappedBy = "loadBalancer", fetch = FetchType.EAGER)
     private Set<LoadBalancerJoinVip> loadBalancerJoinVipSet = new HashSet<LoadBalancerJoinVip>();
 
@@ -194,6 +197,16 @@ public class LoadBalancer extends Entity implements Serializable {
         if (!AtlasTypeHelper.isValidLoadBalancerStatus(status)) throw new RuntimeException("Load balancer status not supported.");
         this.status = status;
     }
+
+    public Boolean isCreatedOnAdapter() {
+        return created_on_adapter;
+    }
+
+    public void setCreatedOnAdapter(Boolean createdOnAdapter) {
+        if (!AtlasTypeHelper.isValidLoadBalancerStatus(status)) throw new RuntimeException("Load balancer status not supported.");
+        this.created_on_adapter = createdOnAdapter;
+    }
+
 
     private static String valueOrNull(Object obj) {
         return obj == null ? "null" : obj.toString();

--- a/core-persistence/src/main/java/org/openstack/atlas/service/domain/repository/impl/LoadBalancerRepositoryImpl.java
+++ b/core-persistence/src/main/java/org/openstack/atlas/service/domain/repository/impl/LoadBalancerRepositoryImpl.java
@@ -180,8 +180,9 @@ public class LoadBalancerRepositoryImpl implements LoadBalancerRepository {
         }
         final boolean isActive = lb.getStatus().equals(CoreLoadBalancerStatus.ACTIVE);
         final boolean isPendingOrActive = lb.getStatus().equals(CoreLoadBalancerStatus.PENDING_UPDATE) || isActive;
+        final boolean isError = lb.getStatus().equals(CoreLoadBalancerStatus.ERROR);
 
-        if (allowConcurrentModifications ? isPendingOrActive : isActive) {
+        if (isError  || (allowConcurrentModifications ? isPendingOrActive : isActive)) {
             lb.setStatus(newStatus);
             lb.setUpdated(Calendar.getInstance());
             entityManager.merge(lb);

--- a/core-persistence/src/main/java/org/openstack/atlas/service/domain/service/impl/LoadBalancerServiceImpl.java
+++ b/core-persistence/src/main/java/org/openstack/atlas/service/domain/service/impl/LoadBalancerServiceImpl.java
@@ -121,7 +121,6 @@ public class LoadBalancerServiceImpl implements LoadBalancerService {
                 LoadBalancer dbLoadBalancer = loadBalancerRepository.getByIdAndAccountId(loadBalancerId, accountId);
                 if (!dbLoadBalancer.getStatus().equals(CoreLoadBalancerStatus.ACTIVE)) {
                     LOG.warn(StringHelper.immutableLoadBalancer(dbLoadBalancer));
-                    badLbStatusIds.add(loadBalancerId);
                 }
             } catch (EntityNotFoundException e) {
                 badLbIds.add(loadBalancerId);

--- a/core-persistence/src/main/java/org/openstack/atlas/service/domain/service/impl/LoadBalancerServiceImpl.java
+++ b/core-persistence/src/main/java/org/openstack/atlas/service/domain/service/impl/LoadBalancerServiceImpl.java
@@ -121,6 +121,9 @@ public class LoadBalancerServiceImpl implements LoadBalancerService {
                 LoadBalancer dbLoadBalancer = loadBalancerRepository.getByIdAndAccountId(loadBalancerId, accountId);
                 if (!dbLoadBalancer.getStatus().equals(CoreLoadBalancerStatus.ACTIVE)) {
                     LOG.warn(StringHelper.immutableLoadBalancer(dbLoadBalancer));
+                    if (!dbLoadBalancer.getStatus().equals(CoreLoadBalancerStatus.ERROR)) {
+                        badLbIds.add(loadBalancerId); 
+                    }
                 }
             } catch (EntityNotFoundException e) {
                 badLbIds.add(loadBalancerId);


### PR DESCRIPTION
This pull request introduces the following FIX:

When a LoadBalancer cannot be created by the adapter, it is removed from the Atlas DB (instead of marking it in an ERROR status), and will have the status changed to DELETED as a consequence.

When a LoadBalancer whose status is in ERROR condition is deleted by the user, now this loadBalancer can be removed from the DB as long as the adapter can successfully remove from the device too. Otherwise, its status will stay as an ERROR condition. 
